### PR TITLE
Timer fix + ui update

### DIFF
--- a/src/OasisPro.pro.user
+++ b/src/OasisPro.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.11.0, 2022-04-04T17:20:51. -->
+<!-- Written by QtCreator 4.11.0, 2022-04-04T23:21:01. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -175,6 +175,7 @@ void MainWindow::endSession(){
     sessionTimer->stop();
     currTimerCount = 0;
     currentIntensity = 0;
+    ui->remainingTimeLabel->setText("Remaining Session Time: 0:0:0");
     ui->checkBtn->blockSignals(false);
     ui->saveBtn->blockSignals(true);
     therapyInProgress = false;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -404,28 +404,28 @@
       <item>
        <widget class="QPushButton" name="SessionType1">
         <property name="text">
-         <string>type 1</string>
+         <string>MET</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QPushButton" name="SessionType2">
         <property name="text">
-         <string>type 2</string>
+         <string>Delta</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QPushButton" name="SessionType3">
         <property name="text">
-         <string>type 3</string>
+         <string>Alpha</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QPushButton" name="SessionType4">
         <property name="text">
-         <string>type 4</string>
+         <string>Theta</string>
         </property>
        </widget>
       </item>
@@ -525,7 +525,7 @@
       </rect>
      </property>
      <property name="text">
-      <string>Remaining Session Time: </string>
+      <string>Remaining Session Time: 0:0:0</string>
      </property>
     </widget>
     <widget class="QLabel" name="connectionQuality">


### PR DESCRIPTION
- The timer now displays 0:0:0 when the device is turned off during a running session.

- The ui now displays actual options
1. MET
2. Delta
3. Alpha
4: Theta